### PR TITLE
Add isorecursive types

### DIFF
--- a/examples.tlc
+++ b/examples.tlc
@@ -12,7 +12,9 @@ let x = {1, true, 3} in x.2
 
 (<none=unit>) as <none: Unit, some: Nat>
 
-case <some=3> of <none=x> => 0 | <some=x> => x
+case <some=3> of
+    <none=x> => 0
+  | <some=x> => x
 
 let ff = λie: Nat -> Bool .
   λx: Nat .
@@ -60,3 +62,7 @@ if true then {a=1} else {a=1, b=2}
 (<val=0>) as Top
 
 if true then 0 else true
+
+fold
+  [mu X . <nil: Unit, cons: {Nat, X}>]
+  (<nil=unit>) as <nil: Unit, cons: {Nat, mu X . <nil: Unit, cons: {Nat, X}>}>

--- a/examples.tlc
+++ b/examples.tlc
@@ -63,6 +63,22 @@ if true then {a=1} else {a=1, b=2}
 
 if true then 0 else true
 
-fold
+let nil =
+  fold
   [mu X . <nil: Unit, cons: {Nat, X}>]
   (<nil=unit>) as <nil: Unit, cons: {Nat, mu X . <nil: Unit, cons: {Nat, X}>}>
+in
+let cons =
+  λn: Nat .
+    λl: (mu X . <nil: Unit, cons: {Nat, X}>) .
+      fold
+      [mu X . <nil: Unit, cons: {Nat, X}>]
+      (<cons={n, l}>) as <nil: Unit, cons: {Nat, mu X . <nil: Unit, cons: {Nat, X}>}>
+in
+let head =
+  λl: (mu X . <nil: Unit, cons: {Nat, X}>) . (
+    case unfold [mu X . <nil: Unit, cons: {Nat, X}>] l of
+        <nil=u> => 0
+      | <cons=p> => (p.1))
+in
+head (cons 3 nil)

--- a/examples.tlc
+++ b/examples.tlc
@@ -6,6 +6,8 @@ let x = {1, true, 3} in x.2
 
 {a=1} as {a=Nat}
 
+{1, 2, 3} as {Nat, Nat, Nat}
+
 <none=unit>
 
 (<none=unit>) as <none: Unit, some: Nat>

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -7,7 +7,9 @@ exception SyntaxError of string
 
 let white = [' ' '\t' '\n']+
 
-let ident = ['A'-'Z' 'a'-'z' '_']['A'-'Z' 'a'-'z' '_' '0'-'9' '\'']*
+let ident = ['a'-'z' '_']['A'-'Z' 'a'-'z' '_' '0'-'9' '\'']*
+
+let tyident = ['A'-'Z']['A'-'Z' 'a'-'z' '_' '0'-'9' '\'']*
 
 let intv = ['0'-'9']+
 
@@ -15,6 +17,7 @@ rule read =
   parse
   | white    { read lexbuf }
   | "unit"   { UNIT }
+  | "mu"     { MU }
   | "lambda" { LAMBDA }
   | "Bool"   { TYBOOL }
   | "Nat"    { TYNAT }
@@ -22,6 +25,7 @@ rule read =
   | "Ref"    { TYREF }
   | "Top"    { TYTOP }
   | "λ"      { LAMBDA }
+  | "μ"      { MU }
   | "->"     { ARROW }
   | "=>"     { FATARROW }
   | "|"      { VBAR }
@@ -54,6 +58,7 @@ rule read =
   | "of"     { OF }
   | "fix"    { FIX }
   | "ref"    { REF }
+  | tyident  { TYIDENT (Lexing.lexeme lexbuf) } 
   | ident    { IDENT (Lexing.lexeme lexbuf) }
   | intv     { INTV (int_of_string (Lexing.lexeme lexbuf)) }
   | _        { raise (SyntaxError ("Unexpected char: " ^ Lexing.lexeme lexbuf)) }

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -35,6 +35,8 @@ rule read =
   | ")"      { RPAREN }
   | "{"      { LCURLY }
   | "}"      { RCURLY }
+  | "["      { LSQUARE }
+  | "]"      { RSQUARE }
   | "<"      { LT }
   | ">"      { GT }
   | ":"      { COLON }
@@ -58,6 +60,8 @@ rule read =
   | "of"     { OF }
   | "fix"    { FIX }
   | "ref"    { REF }
+  | "fold"   { FOLD }
+  | "unfold" { UNFOLD }
   | tyident  { TYIDENT (Lexing.lexeme lexbuf) } 
   | ident    { IDENT (Lexing.lexeme lexbuf) }
   | intv     { INTV (int_of_string (Lexing.lexeme lexbuf)) }

--- a/src/main.ml
+++ b/src/main.ml
@@ -28,7 +28,7 @@ let process_term s =
     let ast = (Parser.toplevel Lexer.read lexbuf) emptycontext in
     let (result, _) = Eval.eval emptycontext emptystore ast in
     let ty = Types.typeof emptycontext ast in
-    print_endline ((printtm emptycontext result) ^ " : " ^ (printty ty))
+    print_endline ((printtm emptycontext result) ^ " : " ^ (printty emptycontext ty))
   with
     | SyntaxError msg -> prerr_endline msg
     | Parser.Error -> prerr_endline "Parsing error"

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -101,10 +101,10 @@ AppTerm:
   | REF PathTerm            { fun ctx -> TmRef($2 ctx) }
   | BANG PathTerm           { fun ctx -> TmDeref($2 ctx) } 
   | LT IDENT EQ PathTerm GT { fun ctx -> TmTag($2, $4 ctx) }
-  | FOLD LSQUARE Type RSQUARE PathTerm
-      { fun ctx -> TmFold($3 ctx, $5 ctx) }
-  | UNFOLD LSQUARE Type RSQUARE PathTerm
-      { fun ctx -> TmUnfold($3 ctx, $5 ctx) } ;
+  | FOLD LSQUARE Type RSQUARE
+      { fun ctx -> TmFold($3 ctx) }
+  | UNFOLD LSQUARE Type RSQUARE
+      { fun ctx -> TmUnfold($3 ctx) } ;
 
 PathTerm:
   | PathTerm DOT INTV  { fun ctx -> TmProj($1 ctx, string_of_int $3)}

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -54,6 +54,10 @@ open Context
 
 %token MU
 %token <string> TYIDENT
+%token LSQUARE
+%token RSQUARE
+%token FOLD
+%token UNFOLD
 
 %start toplevel
 %type <Context.context -> Syntax.term> toplevel
@@ -95,8 +99,12 @@ AppTerm:
   | ISZERO PathTerm         { fun ctx -> TmIsZero($2 ctx) }
   | FIX PathTerm            { fun ctx -> TmFix($2 ctx) }
   | REF PathTerm            { fun ctx -> TmRef($2 ctx) }
-  | BANG PathTerm           { fun ctx -> TmDeref($2 ctx) } ;
+  | BANG PathTerm           { fun ctx -> TmDeref($2 ctx) } 
   | LT IDENT EQ PathTerm GT { fun ctx -> TmTag($2, $4 ctx) }
+  | FOLD LSQUARE Type RSQUARE PathTerm
+      { fun ctx -> TmFold($3 ctx, $5 ctx) }
+  | UNFOLD LSQUARE Type RSQUARE PathTerm
+      { fun ctx -> TmUnfold($3 ctx, $5 ctx) } ;
 
 PathTerm:
   | PathTerm DOT INTV  { fun ctx -> TmProj($1 ctx, string_of_int $3)}

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -52,6 +52,9 @@ open Context
 %token TYREF
 %token TYTOP
 
+%token MU
+%token <string> TYIDENT
+
 %start toplevel
 %type <Context.context -> Syntax.term> toplevel
 
@@ -67,7 +70,7 @@ term:
   | LAMBDA IDENT COLON Type DOT term 
     { fun ctx ->
         let ctx1 = addbinding ctx $2 NameBind in
-        TmAbs($2, $4, $6 ctx1) }
+        TmAbs($2, $4 ctx1, $6 ctx1) }
   | IF term THEN term ELSE term
     { fun ctx -> TmIf($2 ctx, $4 ctx, $6 ctx) }
   | LET IDENT EQ term IN term
@@ -77,7 +80,7 @@ term:
   | LETREC IDENT COLON Type EQ term IN term
     { fun ctx ->
         let ctx1 = addbinding ctx $2 NameBind in
-        let recfunc = TmFix(TmAbs($2, $4, $6 ctx1)) in
+        let recfunc = TmFix(TmAbs($2, $4 ctx1, $6 ctx1)) in
         TmLet($2, recfunc, $8 ctx1) }
   | CASE term OF Cases
         { fun ctx -> TmCase($2 ctx, $4 ctx) }
@@ -101,7 +104,7 @@ PathTerm:
   | AscribeTerm        { $1 } ;
 
 AscribeTerm:
-  | ATerm AS Type               { fun ctx -> TmAscribe($1 ctx, $3) }
+  | ATerm AS Type               { fun ctx -> TmAscribe($1 ctx, $3 ctx) }
   | ATerm                       { $1 } ;
 
 TermSeq:
@@ -166,49 +169,56 @@ Field:
 (* type fields separated by = *)
 TypeFieldsEq:
   | /* empty */
-    { [] }
-  | NETypeFieldsEq { $1 } ;
+    { fun _ -> [] }
+  | NETypeFieldsEq { fun ctx -> $1 ctx } ;
 
 NETypeFieldsEq:
-  | TypeFieldEq { [$1] } 
+  | TypeFieldEq { fun ctx -> [$1 ctx] } 
   | TypeFieldEq COMMA NETypeFieldsEq
-      { let (new_label, ty) = $1 in
-        let existing_fields = $3 in
-        if List.mem_assoc new_label existing_fields then
-        existing_fields else
-        (new_label, ty) :: existing_fields } ;  
+      { fun ctx ->
+          let (new_label, ty) = $1 ctx in
+          let existing_fields = $3 ctx in
+          if List.mem_assoc new_label existing_fields then
+          existing_fields else
+          (new_label, ty) :: existing_fields } ;
 
 TypeFieldEq:
-  | IDENT EQ Type { ($1, $3) } ;
+  | IDENT EQ Type { fun ctx -> ($1, $3 ctx) } ;
 
 (* type fields separated by : *)
 TypeFieldsColon:
   | /* empty */
-    { [] }
-  | NETypeFieldsColon { $1 } ;
+    { fun _ -> [] }
+  | NETypeFieldsColon { fun ctx -> $1 ctx } ;
 
 NETypeFieldsColon:
-  | TypeFieldColon { [$1] } 
+  | TypeFieldColon { fun ctx -> [$1 ctx] } 
   | TypeFieldColon COMMA NETypeFieldsColon
-      { let (new_label, ty) = $1 in
-        let existing_fields = $3 in
-        if List.mem_assoc new_label existing_fields then
-        existing_fields else
-        (new_label, ty) :: existing_fields } ;  
+      { fun ctx ->
+          let (new_label, ty) = $1 ctx in
+          let existing_fields = $3 ctx in
+          if List.mem_assoc new_label existing_fields then
+          existing_fields else
+          (new_label, ty) :: existing_fields } ;  
 
 TypeFieldColon:
-  | IDENT COLON Type { ($1, $3) } ;
+  | IDENT COLON Type { fun ctx -> ($1, $3 ctx) } ;
 
 Type:
-  | AType            { $1 }
-  | TYREF AType      { TyRef($2) }
-  | AType ARROW Type { TyArr($1, $3) } ;
+  | AType            { fun ctx -> $1 ctx }
+  | TYREF AType      { fun ctx -> TyRef($2 ctx) }
+  | AType ARROW Type { fun ctx -> TyArr($1 ctx, $3 ctx) }
+  | MU TYIDENT DOT Type
+      { fun ctx ->
+          let ctx1 = addbinding ctx $2 NameBind in
+          TyRec($2, $4 ctx1) } ;
 
 AType:
-  | LPAREN Type RPAREN         { $2 }
-  | LCURLY TypeFieldsEq RCURLY { TyRecord($2) }
-  | LT TypeFieldsColon GT      { TyVariant($2) }
-  | TYUNIT                     { TyUnit }
-  | TYBOOL                     { TyBool }
-  | TYNAT                      { TyNat }
-  | TYTOP                      { TyTop } ;
+  | LPAREN Type RPAREN         { fun ctx -> $2 ctx }
+  | LCURLY TypeFieldsEq RCURLY { fun ctx -> TyRecord($2 ctx) }
+  | LT TypeFieldsColon GT      { fun ctx -> TyVariant($2 ctx) }
+  | TYIDENT                    { fun ctx -> TyVar(name2index ctx $1, ctxlength ctx)}
+  | TYUNIT                     { fun _ -> TyUnit }
+  | TYBOOL                     { fun _ -> TyBool }
+  | TYNAT                      { fun _ -> TyNat }
+  | TYTOP                      { fun _ -> TyTop } ;

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -169,21 +169,22 @@ Field:
 (* type fields separated by = *)
 TypeFieldsEq:
   | /* empty */
-    { fun _ -> [] }
-  | NETypeFieldsEq { fun ctx -> $1 ctx } ;
+    { fun _ _ -> [] }
+  | NETypeFieldsEq { $1 } ;
 
 NETypeFieldsEq:
-  | TypeFieldEq { fun ctx -> [$1 ctx] } 
+  | TypeFieldEq { fun ctx i -> [$1 ctx i] } 
   | TypeFieldEq COMMA NETypeFieldsEq
-      { fun ctx ->
-          let (new_label, ty) = $1 ctx in
-          let existing_fields = $3 ctx in
+      { fun ctx i ->
+          let (new_label, ty) = ($1 ctx i) in
+          let existing_fields = ($3 ctx (i+1)) in
           if List.mem_assoc new_label existing_fields then
           existing_fields else
           (new_label, ty) :: existing_fields } ;
 
 TypeFieldEq:
-  | IDENT EQ Type { fun ctx -> ($1, $3 ctx) } ;
+  | IDENT EQ Type { fun ctx _ -> ($1, $3 ctx) }
+  | Type          { fun ctx i -> (string_of_int i, $1 ctx) } ;
 
 (* type fields separated by : *)
 TypeFieldsColon:
@@ -215,7 +216,7 @@ Type:
 
 AType:
   | LPAREN Type RPAREN         { fun ctx -> $2 ctx }
-  | LCURLY TypeFieldsEq RCURLY { fun ctx -> TyRecord($2 ctx) }
+  | LCURLY TypeFieldsEq RCURLY { fun ctx -> TyRecord($2 ctx 1) }
   | LT TypeFieldsColon GT      { fun ctx -> TyVariant($2 ctx) }
   | TYIDENT                    { fun ctx -> TyVar(name2index ctx $1, ctxlength ctx)}
   | TYUNIT                     { fun _ -> TyUnit }

--- a/src/print.ml
+++ b/src/print.ml
@@ -17,11 +17,12 @@ let rec printty ctx ty = match ty with
   | TyRec(x, ty) ->
       let ctx', x' = pickfreshname ctx x in
       ("μ" ^ x' ^ "." ^ printty ctx' ty)
-  | TyVar(i, n) ->
-      if ctxlength ctx = n then
+  | TyVar(i, n) -> let (n, _) = getbinding ctx i in n
+(*       if ctxlength ctx = n then
         let (n, _) = getbinding ctx i in n
       else
-        "bad index"
+        "expected context of size " ^ string_of_int n ^
+        " but got " ^ string_of_int (ctxlength ctx) *)
 
 let rec printtm (ctx: context) (t: term) = match t with
   | TmVar(i, n) ->
@@ -65,4 +66,7 @@ let rec printtm (ctx: context) (t: term) = match t with
   | TmDeref(t) -> "!" ^ printtm ctx t
   | TmAssign(t1, t2) -> printtm ctx t1 ^ " := " ^ printtm ctx t2
   | TmLoc(i) -> "<loc #" ^ string_of_int i ^ ">"
+  | TmFold(ty) -> "fold " ^ "[" ^ printty ctx ty ^ "]"
+  | TmUnfold(ty) -> "unfold " ^ "[" ^ printty ctx ty ^ "]"
+  | TmCase(t, cases) -> "case " ^ printtm ctx t ^ " of " ^ (String.concat " | " (List.map (fun (c, (v, t)) -> "<" ^ c ^ "=" ^ "v" ^ ">" ^ " => " ^ (printtm (addbinding ctx v NameBind) t)) cases))
   | _ -> "TODO"

--- a/src/print.ml
+++ b/src/print.ml
@@ -1,19 +1,27 @@
 open Syntax
 open Context
 
-let rec printty ty = match ty with
+let rec printty ctx ty = match ty with
   | TyBool -> "Bool"
   | TyNat -> "Nat"
   | TyUnit -> "Unit"
   | TyTop -> "TyTop"
   | TyRecord(tys) ->
-      let printfield (label, fieldty) = label ^ "=" ^ (printty fieldty) in
+      let printfield (label, fieldty) = label ^ "=" ^ (printty ctx fieldty) in
       "{" ^ (String.concat ", " (List.map printfield tys)) ^ "}"
-  | TyArr(ty1, ty2) -> printty ty1 ^ " -> " ^ printty ty2
+  | TyArr(ty1, ty2) -> printty ctx ty1 ^ " -> " ^ printty ctx ty2
   | TyVariant(tys) ->
-      let printfield (label, fieldty) = label ^ ": " ^ (printty fieldty) in
+      let printfield (label, fieldty) = label ^ ": " ^ (printty ctx fieldty) in
       "<" ^ (String.concat ", " (List.map printfield tys)) ^ ">" 
-  | TyRef(ty) -> "Ref " ^ printty ty
+  | TyRef(ty) -> "Ref " ^ printty ctx ty
+  | TyRec(x, ty) ->
+      let ctx', x' = pickfreshname ctx x in
+      ("μ" ^ x' ^ "." ^ printty ctx' ty)
+  | TyVar(i, n) ->
+      if ctxlength ctx = n then
+        let (n, _) = getbinding ctx i in n
+      else
+        "bad index"
 
 let rec printtm (ctx: context) (t: term) = match t with
   | TmVar(i, n) ->
@@ -50,7 +58,7 @@ let rec printtm (ctx: context) (t: term) = match t with
       let fs = List.map printfield fields in
       "{" ^ (String.concat "," fs) ^ "}"
   | TmProj(t, l) -> printtm ctx t ^ "." ^ l
-  | TmAscribe(t, ty) -> printtm ctx t ^ " as " ^ printty ty
+  | TmAscribe(t, ty) -> printtm ctx t ^ " as " ^ printty ctx ty
   | TmTag(s, t) -> "<" ^ s ^ "=" ^ printtm ctx t ^ ">"
   | TmFix(t) -> "fix " ^ printtm ctx t
   | TmRef(t) -> "ref " ^ printtm ctx t

--- a/src/print.mli
+++ b/src/print.mli
@@ -1,7 +1,8 @@
+open Context
 open Syntax
 
 (* Get display string for a type *)
-val printty : ty -> string
+val printty : context -> ty -> string
 
 (* Get display string for a term *)
-val printtm : Context.context -> term -> string
+val printtm : context -> term -> string

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -7,6 +7,8 @@ type ty =
   | TyArr of ty * ty
   | TyRef of ty
   | TyTop
+  | TyRec of string * ty
+  | TyVar of int * int
 
 type term = 
   | TmVar of int * int

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -33,5 +33,5 @@ type term =
   | TmLoc of int
   | TmDeref of term
   | TmAssign of term * term
-  | TmFold of ty * term
-  | TmUnfold of ty * term
+  | TmFold of ty
+  | TmUnfold of ty

--- a/src/syntax.mli
+++ b/src/syntax.mli
@@ -33,3 +33,5 @@ type term =
   | TmLoc of int
   | TmDeref of term
   | TmAssign of term * term
+  | TmFold of ty * term
+  | TmUnfold of ty * term


### PR DESCRIPTION
Add explicit fold/unfold terms which fold/unfold values of a recursive data type just enough to type check. The syntax `fold [T] t` and `unfold [T] t` are parsed as the application of a `fold(T)` or `unfold(T)` term to the `t` term. This is a little confusing as `(un)fold [T]` isn't a function, but it makes it much simpler to "expand/reduce" recursive types (we can pretty much just copy the term substitution logic and apply it to types).